### PR TITLE
Move factories to namespace

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -392,16 +392,16 @@
         },
         {
             "name": "doctrine/cache",
-            "version": "v1.1",
+            "version": "v1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "2c9761ff1d13e188d5f7378066c1ce2882d7a336"
+                "reference": "d0e4447707a064a5814b18cb0dcc2f24185f6179"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/2c9761ff1d13e188d5f7378066c1ce2882d7a336",
-                "reference": "2c9761ff1d13e188d5f7378066c1ce2882d7a336",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/d0e4447707a064a5814b18cb0dcc2f24185f6179",
+                "reference": "d0e4447707a064a5814b18cb0dcc2f24185f6179",
                 "shasum": ""
             },
             "require": {
@@ -457,7 +457,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2013-08-07 16:04:25"
+            "time": "2013-09-26 19:23:25"
         },
         {
             "name": "doctrine/collections",
@@ -971,16 +971,16 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.3.3",
+            "version": "1.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "16a78140ed2fc01b945cfa539665fadc6a038029"
+                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/16a78140ed2fc01b945cfa539665fadc6a038029",
-                "reference": "16a78140ed2fc01b945cfa539665fadc6a038029",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/acd690379117b042d1c8af1fafd61bde001bf6bb",
+                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb",
                 "shasum": ""
             },
             "require": {
@@ -1007,12 +1007,12 @@
                 }
             ],
             "description": "FilterIterator implementation that filters files based on a list of suffixes.",
-            "homepage": "http://www.phpunit.de/",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
             "keywords": [
                 "filesystem",
                 "iterator"
             ],
-            "time": "2012-10-11 11:44:38"
+            "time": "2013-10-10 15:34:57"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1154,16 +1154,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "3.7.27",
+            "version": "3.7.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "4b024e753e3421837afbcca962c8724c58b39376"
+                "reference": "3b97c8492bcafbabe6b6fbd2ab35f2f04d932a8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4b024e753e3421837afbcca962c8724c58b39376",
-                "reference": "4b024e753e3421837afbcca962c8724c58b39376",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3b97c8492bcafbabe6b6fbd2ab35f2f04d932a8d",
+                "reference": "3b97c8492bcafbabe6b6fbd2ab35f2f04d932a8d",
                 "shasum": ""
             },
             "require": {
@@ -1224,7 +1224,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2013-09-16 03:09:52"
+            "time": "2013-10-17 07:27:40"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1310,17 +1310,17 @@
         },
         {
             "name": "symfony/console",
-            "version": "v2.3.4",
+            "version": "v2.3.6",
             "target-dir": "Symfony/Component/Console",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Console.git",
-                "reference": "db78f8ff7fc9e28d25ff9a0bf6ddf9f0e35fbbe3"
+                "reference": "f880062d56edefb25b36f2defa65aafe65959dc7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/db78f8ff7fc9e28d25ff9a0bf6ddf9f0e35fbbe3",
-                "reference": "db78f8ff7fc9e28d25ff9a0bf6ddf9f0e35fbbe3",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/f880062d56edefb25b36f2defa65aafe65959dc7",
+                "reference": "f880062d56edefb25b36f2defa65aafe65959dc7",
                 "shasum": ""
             },
             "require": {
@@ -1359,21 +1359,21 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "http://symfony.com",
-            "time": "2013-08-17 16:34:49"
+            "time": "2013-09-25 06:04:15"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.3.4",
+            "version": "v2.3.6",
             "target-dir": "Symfony/Component/Yaml",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Yaml.git",
-                "reference": "5a279f1b5f5e1045a6c432354d9ea727ff3a9847"
+                "reference": "6bb881b948368482e1abf1a75c08bcf88a1c5fc3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/5a279f1b5f5e1045a6c432354d9ea727ff3a9847",
-                "reference": "5a279f1b5f5e1045a6c432354d9ea727ff3a9847",
+                "url": "https://api.github.com/repos/symfony/Yaml/zipball/6bb881b948368482e1abf1a75c08bcf88a1c5fc3",
+                "reference": "6bb881b948368482e1abf1a75c08bcf88a1c5fc3",
                 "shasum": ""
             },
             "require": {
@@ -1406,7 +1406,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "http://symfony.com",
-            "time": "2013-08-24 15:26:22"
+            "time": "2013-09-22 18:04:39"
         },
         {
             "name": "zendframework/zend-authentication",
@@ -1593,12 +1593,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/ZendDeveloperTools.git",
-                "reference": "9b9311311fdb562494f89e62eb4649d687b58364"
+                "reference": "23bcd78e80bd963f08b125d80587a640ad7a237d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/ZendDeveloperTools/zipball/9b9311311fdb562494f89e62eb4649d687b58364",
-                "reference": "9b9311311fdb562494f89e62eb4649d687b58364",
+                "url": "https://api.github.com/repos/zendframework/ZendDeveloperTools/zipball/23bcd78e80bd963f08b125d80587a640ad7a237d",
+                "reference": "23bcd78e80bd963f08b125d80587a640ad7a237d",
                 "shasum": ""
             },
             "require": {
@@ -1646,7 +1646,7 @@
                 "module",
                 "zf2"
             ],
-            "time": "2013-07-08 19:52:34"
+            "time": "2013-10-24 10:03:13"
         },
         {
             "name": "zendframework/zend-filter",

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -36,25 +36,25 @@ return [
     'service_manager' => [
         'factories' => [
             // Services that do not have an associated class.
-            'SpiffyAuthorize\Guards'              => 'SpiffyAuthorize\Service\GuardFactory',
-            'SpiffyAuthorize\PermissionProviders' => 'SpiffyAuthorize\Service\ProviderPermissionFactory',
-            'SpiffyAuthorize\RoleProviders'       => 'SpiffyAuthorize\Service\ProviderRoleFactory',
-            'SpiffyAuthorize\ViewStrategy'        => 'SpiffyAuthorize\Service\ViewStrategyFactory',
+            'SpiffyAuthorize\Guards'              => 'SpiffyAuthorize\Factory\GuardFactory',
+            'SpiffyAuthorize\PermissionProviders' => 'SpiffyAuthorize\Factory\ProviderPermissionFactory',
+            'SpiffyAuthorize\RoleProviders'       => 'SpiffyAuthorize\Factory\ProviderRoleFactory',
+            'SpiffyAuthorize\ViewStrategy'        => 'SpiffyAuthorize\Factory\ViewStrategyFactory',
 
             // Services that map directly to a class.
-            'SpiffyAuthorize\Collector\PermissionCollector'            => 'SpiffyAuthorize\Service\CollectorPermissionFactory',
-            'SpiffyAuthorize\Collector\RoleCollector'                  => 'SpiffyAuthorize\Service\CollectorRoleFactory',
-            'SpiffyAuthorize\Guard\RouteGuard'                         => 'SpiffyAuthorize\Service\GuardRouteFactory',
-            'SpiffyAuthorize\Guard\RouteParamsGuard'                   => 'SpiffyAuthorize\Service\GuardRouteParamsFactory',
-            'SpiffyAuthorize\ModuleOptions'                            => 'SpiffyAuthorize\Service\OptionsModuleFactory',
+            'SpiffyAuthorize\Collector\PermissionCollector'            => 'SpiffyAuthorize\Factory\CollectorPermissionFactory',
+            'SpiffyAuthorize\Collector\RoleCollector'                  => 'SpiffyAuthorize\Factory\CollectorRoleFactory',
+            'SpiffyAuthorize\Guard\RouteGuard'                         => 'SpiffyAuthorize\Factory\GuardRouteFactory',
+            'SpiffyAuthorize\Guard\RouteParamsGuard'                   => 'SpiffyAuthorize\Factory\GuardRouteParamsFactory',
+            'SpiffyAuthorize\ModuleOptions'                            => 'SpiffyAuthorize\Factory\OptionsModuleFactory',
             'SpiffyAuthorize\Provider\Identity\AuthenticationProvider' => 'SpiffyAuthorize\Provider\Identity\AuthenticationProviderFactory',
-            'SpiffyAuthorize\Service\RbacService'                      => 'SpiffyAuthorize\Service\RbacServiceFactory',
-            'SpiffyAuthorize\View\UnauthorizedStrategy'                => 'SpiffyAuthorize\Service\ViewStrategyUnauthorizedFactory',
+            'SpiffyAuthorize\Service\RbacService'                      => 'SpiffyAuthorize\Factory\RbacServiceFactory',
+            'SpiffyAuthorize\View\UnauthorizedStrategy'                => 'SpiffyAuthorize\Factory\ViewStrategyUnauthorizedFactory',
         ],
     ],
     'view_helpers' => [
         'factories' => [
-            'isAuthorized' => 'SpiffyAuthorize\Service\ViewHelperIsAuthorizedFactory',
+            'isAuthorized' => 'SpiffyAuthorize\Factory\ViewHelperIsAuthorizedFactory',
         ]
     ],
     'view_manager' => [

--- a/src/SpiffyAuthorize/Factory/AbstractInstanceFactory.php
+++ b/src/SpiffyAuthorize/Factory/AbstractInstanceFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SpiffyAuthorize\Service;
+namespace SpiffyAuthorize\Factory;
 
 use SpiffyAuthorize\ModuleOptions;
 use Zend\ServiceManager\FactoryInterface;

--- a/src/SpiffyAuthorize/Factory/CollectorPermissionFactory.php
+++ b/src/SpiffyAuthorize/Factory/CollectorPermissionFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SpiffyAuthorize\Service;
+namespace SpiffyAuthorize\Factory;
 
 use SpiffyAuthorize\Collector\PermissionCollector;
 use SpiffyAuthorize\Guard\RouteGuard;

--- a/src/SpiffyAuthorize/Factory/CollectorRoleFactory.php
+++ b/src/SpiffyAuthorize/Factory/CollectorRoleFactory.php
@@ -1,26 +1,26 @@
 <?php
 
-namespace SpiffyAuthorize\Service;
+namespace SpiffyAuthorize\Factory;
 
-use SpiffyAuthorize\View\UnauthorizedStrategy;
+use SpiffyAuthorize\Collector\RoleCollector;
+use SpiffyAuthorize\Guard\RouteGuard;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
-class ViewStrategyUnauthorizedFactory implements FactoryInterface
+class CollectorRoleFactory implements FactoryInterface
 {
     /**
      * Create service
      *
      * @param ServiceLocatorInterface $serviceLocator
-     * @return mixed
+     * @return RoleCollector
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
         /** @var \SpiffyAuthorize\ModuleOptions $options */
         $options  = $serviceLocator->get('SpiffyAuthorize\ModuleOptions');
-        $strategy = new UnauthorizedStrategy();
-        $strategy->setTemplate($options->getViewTemplate());
+        $provider = $serviceLocator->get($options->getIdentityProvider());
 
-        return $strategy;
+        return new RoleCollector($provider);
     }
 }

--- a/src/SpiffyAuthorize/Factory/GuardFactory.php
+++ b/src/SpiffyAuthorize/Factory/GuardFactory.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace SpiffyAuthorize\Service;
+namespace SpiffyAuthorize\Factory;
 
 use SpiffyAuthorize\ModuleOptions;
 
-class ProviderPermissionFactory extends AbstractInstanceFactory
+class GuardFactory extends AbstractInstanceFactory
 {
     /**
      * @param ModuleOptions $options
@@ -12,6 +12,6 @@ class ProviderPermissionFactory extends AbstractInstanceFactory
      */
     protected function getInstances(ModuleOptions $options)
     {
-        return $options->getPermissionProviders();
+        return $options->getGuards();
     }
 }

--- a/src/SpiffyAuthorize/Factory/GuardRouteFactory.php
+++ b/src/SpiffyAuthorize/Factory/GuardRouteFactory.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace SpiffyAuthorize\Service;
+namespace SpiffyAuthorize\Factory;
 
-use SpiffyAuthorize\Guard\RouteParamsGuard;
+use SpiffyAuthorize\Guard\RouteGuard;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
-class GuardRouteParamsFactory implements FactoryInterface
+class GuardRouteFactory implements FactoryInterface
 {
     /**
      * Create service
@@ -18,7 +18,7 @@ class GuardRouteParamsFactory implements FactoryInterface
     {
         /** @var \SpiffyAuthorize\ModuleOptions $options */
         $options = $serviceLocator->get('SpiffyAuthorize\ModuleOptions');
-        $guard   = new RouteParamsGuard();
+        $guard   = new RouteGuard();
         $guard->setAuthorizeService($serviceLocator->get($options->getAuthorizeService()));
 
         return $guard;

--- a/src/SpiffyAuthorize/Factory/GuardRouteParamsFactory.php
+++ b/src/SpiffyAuthorize/Factory/GuardRouteParamsFactory.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace SpiffyAuthorize\Service;
+namespace SpiffyAuthorize\Factory;
 
+use SpiffyAuthorize\Guard\RouteParamsGuard;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
-class ViewStrategyFactory implements FactoryInterface
+class GuardRouteParamsFactory implements FactoryInterface
 {
-
     /**
      * Create service
      *
@@ -18,7 +18,9 @@ class ViewStrategyFactory implements FactoryInterface
     {
         /** @var \SpiffyAuthorize\ModuleOptions $options */
         $options = $serviceLocator->get('SpiffyAuthorize\ModuleOptions');
+        $guard   = new RouteParamsGuard();
+        $guard->setAuthorizeService($serviceLocator->get($options->getAuthorizeService()));
 
-        return $serviceLocator->get($options->getViewStrategy());
+        return $guard;
     }
 }

--- a/src/SpiffyAuthorize/Factory/OptionsModuleFactory.php
+++ b/src/SpiffyAuthorize/Factory/OptionsModuleFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SpiffyAuthorize\Service;
+namespace SpiffyAuthorize\Factory;
 
 use SpiffyAuthorize\ModuleOptions;
 use Zend\ServiceManager\FactoryInterface;

--- a/src/SpiffyAuthorize/Factory/ProviderIdentityFactory.php
+++ b/src/SpiffyAuthorize/Factory/ProviderIdentityFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SpiffyAuthorize\Service;
+namespace SpiffyAuthorize\Factory;
 
 use SpiffyAuthorize\Provider\Identity\AuthenticationProvider;
 use Zend\ServiceManager\FactoryInterface;

--- a/src/SpiffyAuthorize/Factory/ProviderPermissionFactory.php
+++ b/src/SpiffyAuthorize/Factory/ProviderPermissionFactory.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace SpiffyAuthorize\Service;
+namespace SpiffyAuthorize\Factory;
 
 use SpiffyAuthorize\ModuleOptions;
 
-class ProviderRoleFactory extends AbstractInstanceFactory
+class ProviderPermissionFactory extends AbstractInstanceFactory
 {
     /**
      * @param ModuleOptions $options
@@ -12,6 +12,6 @@ class ProviderRoleFactory extends AbstractInstanceFactory
      */
     protected function getInstances(ModuleOptions $options)
     {
-        return $options->getRoleProviders();
+        return $options->getPermissionProviders();
     }
 }

--- a/src/SpiffyAuthorize/Factory/ProviderRoleFactory.php
+++ b/src/SpiffyAuthorize/Factory/ProviderRoleFactory.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace SpiffyAuthorize\Service;
+namespace SpiffyAuthorize\Factory;
 
 use SpiffyAuthorize\ModuleOptions;
 
-class GuardFactory extends AbstractInstanceFactory
+class ProviderRoleFactory extends AbstractInstanceFactory
 {
     /**
      * @param ModuleOptions $options
@@ -12,6 +12,6 @@ class GuardFactory extends AbstractInstanceFactory
      */
     protected function getInstances(ModuleOptions $options)
     {
-        return $options->getGuards();
+        return $options->getRoleProviders();
     }
 }

--- a/src/SpiffyAuthorize/Factory/RbacServiceFactory.php
+++ b/src/SpiffyAuthorize/Factory/RbacServiceFactory.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace SpiffyAuthorize\Service;
+namespace SpiffyAuthorize\Factory;
 
+use SpiffyAuthorize\Service\RbacService;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 

--- a/src/SpiffyAuthorize/Factory/ViewHelperIsAuthorizedFactory.php
+++ b/src/SpiffyAuthorize/Factory/ViewHelperIsAuthorizedFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SpiffyAuthorize\Service;
+namespace SpiffyAuthorize\Factory;
 
 use SpiffyAuthorize\View\IsAuthorizedHelper;
 use Zend\ServiceManager\FactoryInterface;

--- a/src/SpiffyAuthorize/Factory/ViewStrategyFactory.php
+++ b/src/SpiffyAuthorize/Factory/ViewStrategyFactory.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace SpiffyAuthorize\Service;
+namespace SpiffyAuthorize\Factory;
 
-use SpiffyAuthorize\Guard\RouteGuard;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
-class GuardRouteFactory implements FactoryInterface
+class ViewStrategyFactory implements FactoryInterface
 {
+
     /**
      * Create service
      *
@@ -18,9 +18,7 @@ class GuardRouteFactory implements FactoryInterface
     {
         /** @var \SpiffyAuthorize\ModuleOptions $options */
         $options = $serviceLocator->get('SpiffyAuthorize\ModuleOptions');
-        $guard   = new RouteGuard();
-        $guard->setAuthorizeService($serviceLocator->get($options->getAuthorizeService()));
 
-        return $guard;
+        return $serviceLocator->get($options->getViewStrategy());
     }
 }

--- a/src/SpiffyAuthorize/Factory/ViewStrategyUnauthorizedFactory.php
+++ b/src/SpiffyAuthorize/Factory/ViewStrategyUnauthorizedFactory.php
@@ -1,26 +1,26 @@
 <?php
 
-namespace SpiffyAuthorize\Service;
+namespace SpiffyAuthorize\Factory;
 
-use SpiffyAuthorize\Collector\RoleCollector;
-use SpiffyAuthorize\Guard\RouteGuard;
+use SpiffyAuthorize\View\UnauthorizedStrategy;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
-class CollectorRoleFactory implements FactoryInterface
+class ViewStrategyUnauthorizedFactory implements FactoryInterface
 {
     /**
      * Create service
      *
      * @param ServiceLocatorInterface $serviceLocator
-     * @return RoleCollector
+     * @return mixed
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
         /** @var \SpiffyAuthorize\ModuleOptions $options */
         $options  = $serviceLocator->get('SpiffyAuthorize\ModuleOptions');
-        $provider = $serviceLocator->get($options->getIdentityProvider());
+        $strategy = new UnauthorizedStrategy();
+        $strategy->setTemplate($options->getViewTemplate());
 
-        return new RoleCollector($provider);
+        return $strategy;
     }
 }

--- a/test/SpiffyAuthorizeTest/Factory/CollectorPermissionFactoryTest.php
+++ b/test/SpiffyAuthorizeTest/Factory/CollectorPermissionFactoryTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace SpiffyAuthorizeTest\Service;
+namespace SpiffyAuthorizeTest\Factory;
 
 use Mockery as m;
 use SpiffyAuthorize\ModuleOptions;
 use SpiffyAuthorize\Provider\Identity\AuthenticationProvider;
-use SpiffyAuthorize\Service\CollectorPermissionFactory;
+use SpiffyAuthorize\Factory\CollectorPermissionFactory;
 use SpiffyAuthorize\Service\RbacService;
 use SpiffyAuthorizeTest\Asset\Identity;
 use SpiffyAuthorizeTest\Asset\RbacRoleProvider;

--- a/test/SpiffyAuthorizeTest/Factory/CollectorRoleFactoryTest.php
+++ b/test/SpiffyAuthorizeTest/Factory/CollectorRoleFactoryTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace SpiffyAuthorizeTest\Service;
+namespace SpiffyAuthorizeTest\Factory;
 
 use Mockery as m;
 use SpiffyAuthorize\ModuleOptions;
 use SpiffyAuthorize\Provider\Identity\AuthenticationProvider;
-use SpiffyAuthorize\Service\CollectorRoleFactory;
+use SpiffyAuthorize\Factory\CollectorRoleFactory;
 use Zend\ServiceManager\ServiceManager;
 
 class CollectorRoleFactoryTest extends \PHPUnit_Framework_TestCase

--- a/test/SpiffyAuthorizeTest/Factory/GuardFactoryTest.php
+++ b/test/SpiffyAuthorizeTest/Factory/GuardFactoryTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace SpiffyAuthorizeTest\Service;
+namespace SpiffyAuthorizeTest\Factory;
 
 use SpiffyAuthorize\ModuleOptions;
-use SpiffyAuthorize\Service\GuardFactory;
+use SpiffyAuthorize\Factory\GuardFactory;
 use Zend\ServiceManager\ServiceManager;
 
 class GuardFactoryTest extends \PHPUnit_Framework_TestCase

--- a/test/SpiffyAuthorizeTest/Factory/GuardRouteFactoryTest.php
+++ b/test/SpiffyAuthorizeTest/Factory/GuardRouteFactoryTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace SpiffyAuthorizeTest\Service;
+namespace SpiffyAuthorizeTest\Factory;
 
 use Mockery as m;
 use SpiffyAuthorize\ModuleOptions;
-use SpiffyAuthorize\Service\GuardRouteFactory;
+use SpiffyAuthorize\Factory\GuardRouteFactory;
 use SpiffyAuthorizeTest\Asset\AuthorizeService;
 use Zend\ServiceManager\ServiceManager;
 

--- a/test/SpiffyAuthorizeTest/Factory/GuardRouteParamsFactoryTest.php
+++ b/test/SpiffyAuthorizeTest/Factory/GuardRouteParamsFactoryTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace SpiffyAuthorizeTest\Service;
+namespace SpiffyAuthorizeTest\Factory;
 
 use Mockery as m;
 use SpiffyAuthorize\ModuleOptions;
-use SpiffyAuthorize\Service\GuardRouteParamsFactory;
+use SpiffyAuthorize\Factory\GuardRouteParamsFactory;
 use SpiffyAuthorizeTest\Asset\AuthorizeService;
 use Zend\ServiceManager\ServiceManager;
 

--- a/test/SpiffyAuthorizeTest/Factory/OptionsModuleFactoryTest.php
+++ b/test/SpiffyAuthorizeTest/Factory/OptionsModuleFactoryTest.php
@@ -2,7 +2,7 @@
 
 namespace SpiffyAuthorizeTest\Factory;
 
-use SpiffyAuthorize\Service\OptionsModuleFactory;
+use SpiffyAuthorize\Factory\OptionsModuleFactory;
 use Zend\ServiceManager\ServiceManager;
 
 class OptionsModuleFactoryTest extends \PHPUnit_Framework_TestCase

--- a/test/SpiffyAuthorizeTest/Factory/ProviderPermissionFactoryTest.php
+++ b/test/SpiffyAuthorizeTest/Factory/ProviderPermissionFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace SpiffyAuthorizeTest\Service;
+namespace SpiffyAuthorizeTest\Factory;
 
-use SpiffyAuthorize\Service\ProviderPermissionFactory;
+use SpiffyAuthorize\Factory\ProviderPermissionFactory;
 use SpiffyTest\Framework\TestCase;
 
 class ProviderPermissionFactoryTest extends TestCase

--- a/test/SpiffyAuthorizeTest/Factory/ProviderRoleFactoryTest.php
+++ b/test/SpiffyAuthorizeTest/Factory/ProviderRoleFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace SpiffyAuthorizeTest\Service;
+namespace SpiffyAuthorizeTest\Factory;
 
-use SpiffyAuthorize\Service\ProviderRoleFactory;
+use SpiffyAuthorize\Factory\ProviderRoleFactory;
 use SpiffyTest\Framework\TestCase;
 
 class ProviderRoleFactoryTest extends TestCase

--- a/test/SpiffyAuthorizeTest/Factory/RbacServiceFactoryTest.php
+++ b/test/SpiffyAuthorizeTest/Factory/RbacServiceFactoryTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace SpiffyAuthorizeTest\Service;
+namespace SpiffyAuthorizeTest\Factory;
 
 use SpiffyAuthorize\AuthorizeEvent;
 use SpiffyAuthorize\ModuleOptions;
-use SpiffyAuthorize\Service\RbacServiceFactory;
+use SpiffyAuthorize\Factory\RbacServiceFactory;
 use SpiffyAuthorizeTest\Asset\Identity;
 use SpiffyTest\Framework\TestCase;
 

--- a/test/SpiffyAuthorizeTest/Factory/ViewStrategyFactoryTest.php
+++ b/test/SpiffyAuthorizeTest/Factory/ViewStrategyFactoryTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace SpiffyAuthorizeTest\Service;
+namespace SpiffyAuthorizeTest\Factory;
 
 use Mockery as m;
 use SpiffyAuthorize\ModuleOptions;
-use SpiffyAuthorize\Service\ViewStrategyFactory;
+use SpiffyAuthorize\Factory\ViewStrategyFactory;
 use SpiffyAuthorize\View\UnauthorizedStrategy;
 
 class ViewStrategyFactoryTest extends \PHPUnit_Framework_TestCase

--- a/test/SpiffyAuthorizeTest/Factory/ViewStrategyUnauthorizedFactoryTest.php
+++ b/test/SpiffyAuthorizeTest/Factory/ViewStrategyUnauthorizedFactoryTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace SpiffyAuthorizeTest\Service;
+namespace SpiffyAuthorizeTest\Factory;
 
 use Mockery as m;
 use SpiffyAuthorize\ModuleOptions;
-use SpiffyAuthorize\Service\ViewStrategyUnauthorizedFactory;
+use SpiffyAuthorize\Factory\ViewStrategyUnauthorizedFactory;
 use Zend\ServiceManager\ServiceManager;
 
 class ViewStrategyUnauthorizedFactoryTest extends \PHPUnit_Framework_TestCase


### PR DESCRIPTION
It's very confusing to have factories in the same folder as services (RbacService is then lost among all the factories).

This PR just moved all factories to a specific namespace. All tests have been updated.
